### PR TITLE
fix(netlify): publish dist (netlify-static preset output dir)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,6 @@
 [build]
   # Netlify detects bun.lockb and uses Bun natively.
   command = "bun run generate"
-  publish = ".output/public"
+  # On Netlify, Nitro auto-selects the `netlify-static` preset, which outputs the
+  # prerendered site to `dist/` (locally, `nuxt generate` uses `.output/public`).
+  publish = "dist"


### PR DESCRIPTION
Follow-up to #24. The build now succeeds, but the **deploy** step failed:

> Deploy did not succeed: Deploy directory `.output/public` does not exist

**Cause:** On Netlify, `NETLIFY=true` makes Nitro auto-select the `netlify-static` preset, which outputs the prerendered site to `dist/` (locally, `nuxt generate` uses `.output/public`). The `netlify.toml` was publishing `.output/public`.

**Fix:** `publish = "dist"`. Reproduced locally with `NETLIFY=true bun run generate` → `dist/` (complete: index, robots.txt, sitemap.xml, 246 flag pages w/ baked Wikipedia, _redirects, _headers, bundled icons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)