### PR TITLE
fix(perf): preload fonts + eager above-the-fold flags

### DIFF
--- a/app/components/FlagCard.vue
+++ b/app/components/FlagCard.vue
@@ -9,9 +9,12 @@ const props = withDefaults(defineProps<{
   value: CountryValue
   lang?: string
   finished?: boolean
+  /** Above-the-fold cards load eagerly with high priority (avoids pop-in / better LCP). */
+  priority?: boolean
 }>(), {
   lang: 'fr',
-  finished: true
+  finished: true,
+  priority: false
 })
 
 const countryName = computed(() => props.value.country[props.lang]?.split('|')[0] ?? '')
@@ -27,7 +30,8 @@ const capitalName = computed(() => props.value.capital[props.lang]?.split('|')[0
       <img
         :src="`/flags/png/${value.id}.png`"
         :alt="`flag_${value.id}`"
-        loading="lazy"
+        :loading="priority ? 'eager' : 'lazy'"
+        :fetchpriority="priority ? 'high' : undefined"
         decoding="async"
         class="flag"
         :style="finished ? undefined : 'opacity:0.5'"

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -84,11 +84,12 @@ useHead({ bodyAttrs: { class: 'bg-bg' } })
     <!-- Grid -->
     <div class="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-4">
       <FlagCard
-        v-for="value in countriesFiltered"
+        v-for="(value, i) in countriesFiltered"
         :key="`flag_${value.id}`"
         :value="value"
         :finished="value.finished"
         :lang="lang"
+        :priority="i < 8"
       />
     </div>
   </div>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -38,9 +38,14 @@ export default defineNuxtConfig({
   },
 
   fonts: {
+    // The content is French, so only the Latin subsets are needed. Preload the
+    // body (Roboto) and display (Secular One) fonts so they don't visibly swap
+    // in on first load — by default @nuxt/fonts skips preloading any face that
+    // has a unicode-range (i.e. all of them), which left no font preloads.
+    defaults: { subsets: ['latin', 'latin-ext'] },
     families: [
-      { name: 'Roboto', provider: 'google' },
-      { name: 'Secular One', provider: 'google' }
+      { name: 'Roboto', provider: 'google', preload: true },
+      { name: 'Secular One', provider: 'google', preload: true }
     ]
   },
 


### PR DESCRIPTION
On a fresh (uncached) production visit, the title/body fonts visibly swapped in (FOUT) and the first flag images popped in.

- **Fonts:** `@nuxt/fonts` skips preloading any `@font-face` that has a `unicode-range` (all of them), so nothing was preloaded. Set `preload: true` for Roboto + Secular One and trim subsets to `latin`/`latin-ext` (French content) → the 2 primary faces now preload.
- **Flags:** the first 8 cards (above the fold) load `eager` + `fetchpriority=high`; the rest stay `lazy`. Avoids pop-in, improves LCP.

Validated with `NETLIFY=true bun run generate` (513 routes, 2 font preloads, eager first flags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)