### PR TITLE
fix(flags): drop content-visibility:auto (image repaint glitch)

### DIFF
--- a/app/components/FlagCard.vue
+++ b/app/components/FlagCard.vue
@@ -49,9 +49,6 @@ const capitalName = computed(() => props.value.capital[props.lang]?.split('|')[0
 .flag-card {
   display: block;
   text-decoration: none;
-  /* Skip rendering off-screen cards while keeping them in the DOM / prerendered HTML. */
-  content-visibility: auto;
-  contain-intrinsic-size: auto 180px;
 }
 
 .flag-card__inner {


### PR DESCRIPTION
The flag images briefly rendered at their natural aspect ("contain") before snapping to `cover` on first load, on almost every flag.

**Cause:** every `.flag-card` had `content-visibility: auto`. Chromium repaints the image inside a `content-visibility` container when it's first rendered, briefly before `object-fit: cover` takes effect. It's paint-contained, so it never showed as layout shift (CLS = 0) and computed-style probing always read `cover` — a genuine sub-frame paint glitch.

**Fix:** remove `content-visibility: auto` / `contain-intrinsic-size`. Image *fetching* is still deferred via `loading="lazy"` (the real perf goal); rendering 246 tiny cards is cheap. `object-fit: cover` stays inlined in `<head>` so flags are cover from the first paint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)