### PR TITLE
fix(flags): stop contain→cover paint flash (img size + sync decode)

### DIFF
--- a/app/components/FlagCard.vue
+++ b/app/components/FlagCard.vue
@@ -24,15 +24,18 @@ const capitalName = computed(() => props.value.capital[props.lang]?.split('|')[0
 <template>
   <NuxtLink :to="`/flag/${value.id}`" class="flag-card">
     <div class="flag-card__inner">
-      <!-- Native lazy loading: off-screen flags aren't fetched until scrolled near.
-           All critical layout lives in this component's (inlined) scoped CSS so the
-           image is sized correctly on first paint, with no flash of intrinsic size. -->
+      <!-- width/height give the img an intrinsic box matching the card aspect, and
+           decoding="sync" makes the decoded bitmap commit in the same paint as the
+           object-fit:cover layout. Without both, the img paints one frame at the
+           flag's natural aspect (letterboxed "contain") before snapping to cover. -->
       <img
         :src="`/flags/png/${value.id}.png`"
         :alt="`flag_${value.id}`"
+        width="247"
+        height="180"
         :loading="priority ? 'eager' : 'lazy'"
         :fetchpriority="priority ? 'high' : undefined"
-        decoding="async"
+        decoding="sync"
         class="flag"
         :style="finished ? undefined : 'opacity:0.5'"
       >


### PR DESCRIPTION
**Reproduced in pixels** (Playwright, 25fps video + CPU throttle) and fixed.

On every warm reload, the flag `<img>` painted one frame at the PNG's natural aspect (250×167, letterboxed "contain") before `object-fit:cover` composited into the 247×180 card box. The image had **no `width`/`height`** and `decoding="async"`, so the decoded bitmap committed a paint before the object-fit layout. CLS stayed 0.00 (the card box never moves — only the img's internal raster differed for one frame), which is why every screenshot-after-load and computed-style probe missed it.

**Fix:** add `width="247" height="180"` and `decoding="sync"` to the flag `<img>`. A/B test (injecting these before paint) confirmed the contain frame no longer appears — the card goes blank → cover directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)