### PR TITLE
fix(flags): inline object-fit + aspect-ratio (real contain-flash fix)

### DIFF
--- a/app/components/FlagCard.vue
+++ b/app/components/FlagCard.vue
@@ -24,10 +24,12 @@ const capitalName = computed(() => props.value.capital[props.lang]?.split('|')[0
 <template>
   <NuxtLink :to="`/flag/${value.id}`" class="flag-card">
     <div class="flag-card__inner">
-      <!-- width/height give the img an intrinsic box matching the card aspect, and
-           decoding="sync" makes the decoded bitmap commit in the same paint as the
-           object-fit:cover layout. Without both, the img paints one frame at the
-           flag's natural aspect (letterboxed "contain") before snapping to cover. -->
+      <!-- object-fit + aspect-ratio are set INLINE on the element (not only via the
+           scoped .flag rule) so they apply the instant the tag parses. Before the
+           scoped stylesheet applies (pre-hydration window), the browser would size
+           the img from the flag's natural aspect (247x165 → a ~15px letterbox
+           "contain" flash); the inline aspect-ratio:247/180 forces the card box so
+           there is never a letterboxed frame. -->
       <img
         :src="`/flags/png/${value.id}.png`"
         :alt="`flag_${value.id}`"
@@ -35,9 +37,9 @@ const capitalName = computed(() => props.value.capital[props.lang]?.split('|')[0
         height="180"
         :loading="priority ? 'eager' : 'lazy'"
         :fetchpriority="priority ? 'high' : undefined"
-        decoding="sync"
+        decoding="async"
         class="flag"
-        :style="finished ? undefined : 'opacity:0.5'"
+        :style="{ objectFit: 'cover', aspectRatio: '247 / 180', opacity: finished ? undefined : 0.5 }"
       >
       <div class="flag-card__gradient" />
       <div class="flag-card__text">


### PR DESCRIPTION
Measured empirically (Playwright: 25fps video + 40× CPU throttle + automated letterbox detector, 25+ reloads per variant).

**Root cause:** the flag sizing lived only in a Vue **scoped** stylesheet. In the pre-hydration window before that rule applies, the browser sizes the `<img>` from the flag's **natural** aspect → 247×165 with a ~15px letterbox ("contain"), then snaps to cover. The previous `width`/`height` + `decoding="sync"` did **not** win that race (the box was auto-sized from the natural aspect, ignoring the attrs).

**Fix:** set `object-fit:cover` **and** `aspect-ratio:247/180` as an **inline style on the `<img>`**, so they apply the instant the tag parses — independent of the scoped stylesheet.

**Proof:** 0/25 contain frames with the fix even when the `.flag` rule is deleted (vs 40/40 baseline), no happy-path regression. Reverted the ineffective `decoding="sync"` → `async`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)