### PR TITLE
tweak(flags): gentler flag fade-in (0.45s ease-out)

### DIFF
--- a/app/components/FlagCard.vue
+++ b/app/components/FlagCard.vue
@@ -91,7 +91,7 @@ onMounted(() => {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  transition: opacity 0.12s ease, filter 0.15s ease;
+  transition: opacity 0.45s ease-out, filter 0.15s ease;
 }
 
 .flag-card:hover .flag {


### PR DESCRIPTION
The decode-then-reveal fade was 0.12s (too fast/abrupt). Slow to 0.45s ease-out for a smooth reveal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)